### PR TITLE
Add infowindow in google maps

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -12,11 +12,16 @@ $(function(){
           mapTypeId: google.maps.MapTypeId.ROADMAP
         };
         var map = new google.maps.Map(document.getElementById("map-canvas"),mapOpt);
+
         $(gon.latlng).each(function(i){
           var latlng = new google.maps.LatLng( gon.latlng[i].lat, gon.latlng[i].lng, false );
-          var marker_i = new google.maps.Marker({
-          map: map,
-          position: latlng
+          var info_window = new google.maps.InfoWindow({
+            position: latlng,
+            maxWidth: 50,
+            content: '<div class="infoWindow_span_' + gon.room_id[i] + '">' + gon.price[i] + '円</div>'
+          });
+          $(window).on('load', function(){
+            info_window.open(map);
           });
         });
       }else {
@@ -24,4 +29,16 @@ $(function(){
       }
     });
   }
+  $('.listingCardWrapper').hover(
+    function(){
+      roomId = $(this).attr('id');
+      target = '.infoWindow_span_' + roomId;
+      $(target).css('background-color', 'red');
+    },
+    function(){
+      roomId = $(this).attr('id');
+      target = '.infoWindow_span_' + roomId;
+      $(target).css('background-color', 'white');
+    }
+  );
 });

--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -25,3 +25,7 @@
   height: 100vh;
   overflow: auto;
 }
+
+.gm-style-iw + div {
+  display: none;
+}

--- a/app/assets/stylesheets/_tour.scss
+++ b/app/assets/stylesheets/_tour.scss
@@ -9,6 +9,9 @@
   font-size: 30px;
   border-radius: 5px;
   color: white;
+  position: absolute;
+  top: 38px;
+  right: 30px;
 }
 
 label.panel-label {
@@ -145,6 +148,7 @@ ul#tabs-list {
   padding: 0;
   text-align: center;
   border-bottom: 1px solid #dfdfdf;
+  position: relative;
 }
 ul#tabs-list li {
   display: flex;
@@ -201,4 +205,9 @@ main p {
 
 .tour_header{
   margin-left: 180px;
+}
+
+.listing-cards-row{
+  display: flex;
+  flex-wrap: wrap;
 }

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -52,11 +52,15 @@ class RoomsController < ApplicationController
   def search
     @rooms = []
     gon.latlng = []
+    gon.price = []
+    gon.room_id = []
     gon.keyword = params[:form][:address]
-    rooms = Room.near([params[:form][:latitude], params[:form][:longitude]], 50)
+    rooms = Room.near([params[:form][:latitude], params[:form][:longitude]], 2)
     refine_rooms_by_date(rooms)
     @rooms.each do |room|
       gon.latlng.push(lat: room.latitude, lng: room.longitude)
+      gon.price << room.price
+      gon.room_id << room.id
     end
   end
 

--- a/app/controllers/tours_controller.rb
+++ b/app/controllers/tours_controller.rb
@@ -14,7 +14,7 @@ class ToursController < ApplicationController
       @ends.push(params[:end_day])
       @occupancys.push(params[:occupancy])
       @keyword.push(params[:address])
-      rooms = Room.near([params[:latitude], params[:longitude]], 50)
+      rooms = Room.near([params[:latitude], params[:longitude]], 2)
       refine_rooms_by_date(i, rooms, params)
     end
     @rooms.each_with_index do |rooms, i|

--- a/app/views/rooms/shared/_listing-card.html.haml
+++ b/app/views/rooms/shared/_listing-card.html.haml
@@ -1,5 +1,5 @@
 .col-sm-12.col-md-6.space-4
-  .listingCardWrapper
+  .listingCardWrapper{ id: room.id }
     .container-image
       = image_tag(room.image, class: 'listing-image')
     .linktolisting


### PR DESCRIPTION
# What
- 検索結果のページにて、マーカーではなくインフォウインドウで値段表示にする。
- リスティングのページに乗ったときに、地図上のインフォウインドウの表示が変わるように設定

# TODO
- ツアー機能での検索結果ページでは配列を使って上記を行う必要があるので、時間をかけて再度トライする。